### PR TITLE
network request for recipes + persist exoplayer state

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.google.android.exoplayer:exoplayer:2.8.3'
     implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
 
     compileOnly 'org.projectlombok:lombok:1.16.20'
     annotationProcessor 'org.projectlombok:lombok:1.16.20'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".activity.RecipeActivity" />
+        <activity
+            android:name=".activity.RecipeActivity"
+            android:configChanges="orientation|screenSize" />
         <activity
             android:name=".activity.StepActivity"
             android:configChanges="orientation|screenSize" />

--- a/app/src/main/java/com/udacity/bakingapp/activity/RecipeActivity.java
+++ b/app/src/main/java/com/udacity/bakingapp/activity/RecipeActivity.java
@@ -26,6 +26,7 @@ public class RecipeActivity extends AppCompatActivity
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_recipe);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         final Recipe recipe = getIntent().getParcelableExtra(EXTRA_RECIPE);
 
@@ -61,6 +62,12 @@ public class RecipeActivity extends AppCompatActivity
         } else {
             mTwoPane = false;
         }
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
     }
 
     @Override

--- a/app/src/main/java/com/udacity/bakingapp/activity/StepActivity.java
+++ b/app/src/main/java/com/udacity/bakingapp/activity/StepActivity.java
@@ -40,6 +40,7 @@ public class StepActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_step);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         mPlayerView = findViewById(R.id.player_view);
         final String mediaURL = getIntent().getStringExtra(RecipeStepFragment.EXTRA_MEDIA_URL);
@@ -54,6 +55,12 @@ public class StepActivity extends AppCompatActivity {
         mDescription = findViewById(R.id.tv_description);
         final String description = getIntent().getStringExtra(RecipeStepFragment.EXTRA_DESCRIPTION);
         mDescription.setText(description);
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
     }
 
     private void initializePlayer(String mediaURL) {

--- a/app/src/main/java/com/udacity/bakingapp/utilities/GetRecipes.java
+++ b/app/src/main/java/com/udacity/bakingapp/utilities/GetRecipes.java
@@ -1,0 +1,13 @@
+package com.udacity.bakingapp.utilities;
+
+import com.udacity.bakingapp.model.Recipe;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface GetRecipes {
+    @GET("/topher/2017/May/59121517_baking/baking.json")
+    Call<List<Recipe>> getRecipes();
+}

--- a/app/src/main/java/com/udacity/bakingapp/utilities/JsonUtils.java
+++ b/app/src/main/java/com/udacity/bakingapp/utilities/JsonUtils.java
@@ -10,13 +10,12 @@ import java.io.InputStream;
 import java.util.Arrays;
 
 public class JsonUtils {
-
     private static String loadJSONFromAsset(Activity activity) {
         String json;
         try {
-            InputStream is = activity.getAssets().open("baking.json");
+            final InputStream is = activity.getAssets().open("baking.json");
             final int size = is.available();
-            byte[] buffer = new byte[size];
+            final byte[] buffer = new byte[size];
             is.read(buffer);
             is.close();
             json = new String(buffer, "UTF-8");
@@ -28,9 +27,9 @@ public class JsonUtils {
     }
 
     public static Recipe[] getRecipes(Activity activity) {
-        String json = loadJSONFromAsset(activity);
-        Gson gson = new Gson();
-        Recipe[] recipes = gson.fromJson(json, Recipe[].class);
+        final String json = loadJSONFromAsset(activity);
+        final Gson gson = new Gson();
+        final Recipe[] recipes = gson.fromJson(json, Recipe[].class);
         return recipes;
     }
 

--- a/app/src/main/java/com/udacity/bakingapp/utilities/RetrofitUtils.java
+++ b/app/src/main/java/com/udacity/bakingapp/utilities/RetrofitUtils.java
@@ -1,0 +1,20 @@
+package com.udacity.bakingapp.utilities;
+
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class RetrofitUtils {
+    private static final String BASE_URL = "https://d17h27t6h515a5.cloudfront.net";
+
+    private static Retrofit retrofit;
+
+    public static retrofit2.Retrofit getRetrofitInstance() {
+        if (retrofit == null) {
+            retrofit = new retrofit2.Retrofit.Builder()
+                    .baseUrl(BASE_URL)
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .build();
+        }
+        return retrofit;
+    }
+}


### PR DESCRIPTION
Handling review feedback.
* Recipe JSON list was supposed to be retrieved from external url at https://d17h27t6h515a5.cloudfront.net/topher/2017/May/59121517_baking/baking.json
  * Added `Retrofit` library to handle network request
* ExoPlayer state can be better handled by releasing during `onPause` and `onStop`, and persisting in bundle `onSaveInstanceState`