### PR TITLE
use RecipeStepFragment in StepActivity to reduce duplicated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Resources:
 
 ## Screenshots
 
-![widget example](https://github.com/coreen/baking-app/blob/master/Widget_Example.png)
+<img src="Widget_Example.png" alt="widget example" width="270" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "com.udacity.bakingapp"
-        minSdkVersion 24
+        minSdkVersion 16
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,19 +13,15 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <!-- Resource: https://stackoverflow.com/questions/5620033/onconfigurationchanged-not-getting-called -->
-        <activity
-            android:name=".activity.MainActivity"
-            android:configChanges="orientation|screenSize">
+        <activity android:name=".activity.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".activity.RecipeActivity"
-            android:configChanges="orientation|screenSize" />
+        <activity android:name=".activity.RecipeActivity" />
+        <!-- Resource: https://stackoverflow.com/questions/5620033/onconfigurationchanged-not-getting-called -->
         <activity
             android:name=".activity.StepActivity"
             android:configChanges="orientation|screenSize" />

--- a/app/src/main/java/com/udacity/bakingapp/activity/MainActivity.java
+++ b/app/src/main/java/com/udacity/bakingapp/activity/MainActivity.java
@@ -52,7 +52,8 @@ public class MainActivity extends AppCompatActivity {
                         (AdapterView<?> adapterView, View view, int position, long l)
                                 -> launchRecipeActivity(position));
 
-                // Set initial column number
+                // Set column number, onCreate called every orientation change
+                // if configChanges not set in AndroidManifest
                 Configuration config = getResources().getConfiguration();
                 if (config.orientation == Configuration.ORIENTATION_LANDSCAPE) {
                     mGridView.setNumColumns(3);
@@ -65,20 +66,6 @@ public class MainActivity extends AppCompatActivity {
                 Timber.e("Error retrieving recipes from network", t);
             }
         });
-    }
-
-    // Resource: https://developer.android.com/guide/topics/resources/runtime-changes#HandlingTheChange
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        Timber.d("onConfigurationChanged orientation: " + newConfig.orientation);
-
-        // Checks the orientation of the screen and updates column number accordingly
-        if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            mGridView.setNumColumns(3);
-        } else if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT) {
-            mGridView.setNumColumns(2);
-        }
     }
 
     // NOTE: all activities need to be included in AndroidManifest in order to launch properly

--- a/app/src/main/java/com/udacity/bakingapp/activity/RecipeActivity.java
+++ b/app/src/main/java/com/udacity/bakingapp/activity/RecipeActivity.java
@@ -10,8 +10,6 @@ import com.udacity.bakingapp.fragment.InstructionListFragment;
 import com.udacity.bakingapp.fragment.RecipeStepFragment;
 import com.udacity.bakingapp.model.Recipe;
 
-import java.util.Arrays;
-
 import timber.log.Timber;
 
 

--- a/app/src/main/java/com/udacity/bakingapp/activity/StepActivity.java
+++ b/app/src/main/java/com/udacity/bakingapp/activity/StepActivity.java
@@ -1,60 +1,32 @@
 package com.udacity.bakingapp.activity;
 
 import android.content.res.Configuration;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.constraint.ConstraintLayout;
-import android.support.constraint.Guideline;
 import android.support.v7.app.AppCompatActivity;
-import android.view.View;
-import android.widget.TextView;
 
-import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.DefaultRenderersFactory;
-import com.google.android.exoplayer2.ExoPlayerFactory;
-import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.source.ExtractorMediaSource;
-import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.ui.PlayerView;
-import com.google.android.exoplayer2.upstream.BandwidthMeter;
-import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
-import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
-import com.google.android.exoplayer2.upstream.TransferListener;
-import com.google.android.exoplayer2.util.Util;
 import com.udacity.bakingapp.R;
 import com.udacity.bakingapp.fragment.RecipeStepFragment;
 
 import timber.log.Timber;
 
 public class StepActivity extends AppCompatActivity {
-
-    private SimpleExoPlayer mExoPlayer;
-    private PlayerView mPlayerView;
-    private Guideline mGuideline;
-    private TextView mDescription;
-
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_step);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        mPlayerView = findViewById(R.id.player_view);
-        final String mediaURL = getIntent().getStringExtra(RecipeStepFragment.EXTRA_MEDIA_URL);
-        if (mediaURL.length() > 0) {
-            initializePlayer(mediaURL);
-        } else {
-            mPlayerView.setVisibility(View.GONE);
-            mGuideline = findViewById(R.id.horizontalHalf);
-            mGuideline.setVisibility(View.GONE);
-        }
+        final Bundle arguments = getIntent().getExtras();
+        Timber.d("Received bundle in StepActivity: " + arguments);
 
-        mDescription = findViewById(R.id.tv_description);
-        final String description = getIntent().getStringExtra(RecipeStepFragment.EXTRA_DESCRIPTION);
-        mDescription.setText(description);
+
+        final RecipeStepFragment recipeStepFragment = new RecipeStepFragment();
+        recipeStepFragment.setArguments(arguments);
+        getSupportFragmentManager()
+                .beginTransaction()
+                .add(R.id.recipe_step_placeholder, recipeStepFragment)
+                .commit();
     }
 
     @Override
@@ -63,61 +35,12 @@ public class StepActivity extends AppCompatActivity {
         return true;
     }
 
-    private void initializePlayer(String mediaURL) {
-        if (mExoPlayer == null) {
-            // Resource: https://gist.github.com/codeshifu/c26bb8a5f27f94d73b3a4888a509927c#file-mainactivity-java-L63
-            mExoPlayer = ExoPlayerFactory.newSimpleInstance(
-                    new DefaultRenderersFactory(this),
-                    new DefaultTrackSelector(),
-                    new DefaultLoadControl());
-            mPlayerView.setPlayer(mExoPlayer);
-
-            // Resource: https://github.com/yusufcakmak/ExoPlayerSample/blob/master/app/src/main/java/com/yusufcakmak/exoplayersample/VideoPlayerActivity.java#L91
-            BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
-            DataSource.Factory mediaDataSourceFactory = new DefaultDataSourceFactory(
-                    this,
-                    Util.getUserAgent(
-                            this,
-                            "BakingApp"),
-                    (TransferListener<? super DataSource>) bandwidthMeter);
-            MediaSource mediaSource = new ExtractorMediaSource.Factory(mediaDataSourceFactory)
-                    .createMediaSource(Uri.parse(mediaURL));
-            mExoPlayer.prepare(mediaSource);
-            mExoPlayer.setPlayWhenReady(true);
-        }
-    }
-
-    private void releasePlayer() {
-        if (mExoPlayer != null) {
-            mExoPlayer.stop();
-            mExoPlayer.release();
-            mExoPlayer = null;
-        }
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        releasePlayer();
-    }
-
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        Timber.d("onConfigurationChanged orientation: " + newConfig.orientation);
 
-        // Checks the orientation of the screen and updates sizing of PlayerView
-        ConstraintLayout.LayoutParams params = (ConstraintLayout.LayoutParams) mPlayerView.getLayoutParams();
-        params.width = params.MATCH_PARENT;
-        if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            // set full screen
-            params.height = params.MATCH_PARENT;
-            mDescription.setVisibility(View.INVISIBLE);
-        } else if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT) {
-            // keep original sizing
-            params.height = 800;
-            mDescription.setVisibility(View.VISIBLE);
-        }
-        mPlayerView.setLayoutParams(params);
+        RecipeStepFragment recipeStepFragment = (RecipeStepFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.recipe_step_placeholder);
+        recipeStepFragment.onConfigurationChanged(newConfig);
     }
 }

--- a/app/src/main/java/com/udacity/bakingapp/fragment/InstructionListFragment.java
+++ b/app/src/main/java/com/udacity/bakingapp/fragment/InstructionListFragment.java
@@ -16,7 +16,6 @@ import com.udacity.bakingapp.R;
 import com.udacity.bakingapp.adapter.IngredientAdapter;
 import com.udacity.bakingapp.adapter.StepAdapter;
 import com.udacity.bakingapp.model.Recipe;
-import com.udacity.bakingapp.utilities.JsonUtils;
 
 public class InstructionListFragment
         extends Fragment

--- a/app/src/main/res/layout/activity_step.xml
+++ b/app/src/main/res/layout/activity_step.xml
@@ -1,39 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <com.google.android.exoplayer2.ui.PlayerView
-        android:id="@+id/player_view"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
-        android:layout_marginTop="0dp"
-        android:layout_marginRight="0dp"
-        app:layout_constraintRight_toRightOf="parent"
-        android:layout_marginBottom="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/horizontalHalf"
-        android:layout_marginLeft="0dp"
-        app:layout_constraintLeft_toLeftOf="parent" />
-
-    <android.support.constraint.Guideline
-        android:id="@+id/horizontalHalf"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.5"
-        tools:layout_editor_absoluteX="0dp"
-        tools:layout_editor_absoluteY="256dp" />
-
-    <TextView
-        android:id="@+id/tv_description"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/horizontalHalf"
-        android:layout_marginLeft="12dp"
-        android:layout_marginTop="42dp" />
-
-</android.support.constraint.ConstraintLayout>
+    android:id="@+id/recipe_step_placeholder"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />


### PR DESCRIPTION
Set minSDK to 16 so conditional ExoPlayer releasing can occur.

Retrieve fragment to update configuration, so only have single instance of ExoPlayer to save/restore state on orientation change.
* Note: It is **required** to have `configChanges` in order to call `onConfigurationChanged`, otherwise the `onCreate` method will be called for changes to the configuration (i.e. orientation changes)
  * See `MainActivity` and `StepActivity` for the difference
  * The `configChanges` setup is likely more performant