### PR TITLE
switching screen activity restoration

### DIFF
--- a/app/src/main/java/com/udacity/bakingapp/activity/RecipeActivity.java
+++ b/app/src/main/java/com/udacity/bakingapp/activity/RecipeActivity.java
@@ -39,24 +39,33 @@ public class RecipeActivity extends AppCompatActivity
                 InstructionListFragment.EXTRA_STEPS,
                 recipe.getSteps());
 
-        final InstructionListFragment instructionListFragment = new InstructionListFragment();
-        instructionListFragment.setArguments(instructionBundle);
-        getSupportFragmentManager()
-                .beginTransaction()
-                .add(R.id.instruction_list_placeholder, instructionListFragment)
-                .commit();
+        InstructionListFragment instructionListFragment =
+                (InstructionListFragment) getSupportFragmentManager()
+                        .findFragmentById(R.id.instruction_list_placeholder);
+        if (instructionListFragment == null) {
+            instructionListFragment = new InstructionListFragment();
+            instructionListFragment.setArguments(instructionBundle);
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .add(R.id.instruction_list_placeholder, instructionListFragment)
+                    .commit();
+        }
 
         // mTwoPane detection
         if(findViewById(R.id.recipe_step_placeholder) != null) {
             Timber.d("Detected tablet in horizontal mode, using 2 panes");
             mTwoPane = true;
-            // create fragment
-            final RecipeStepFragment recipeStepFragment = new RecipeStepFragment();
-            recipeStepFragment.setArguments(populateBundleFromStep(recipe.getSteps()[0]));
-            getSupportFragmentManager()
-                    .beginTransaction()
-                    .add(R.id.recipe_step_placeholder, recipeStepFragment)
-                    .commit();
+            // create fragment if does not exist
+            RecipeStepFragment recipeStepFragment = (RecipeStepFragment) getSupportFragmentManager()
+                    .findFragmentById(R.id.recipe_step_placeholder);
+            if (recipeStepFragment == null) {
+                recipeStepFragment = new RecipeStepFragment();
+                recipeStepFragment.setArguments(populateBundleFromStep(recipe.getSteps()[0]));
+                getSupportFragmentManager()
+                        .beginTransaction()
+                        .add(R.id.recipe_step_placeholder, recipeStepFragment)
+                        .commit();
+            }
         } else {
             mTwoPane = false;
         }

--- a/app/src/main/java/com/udacity/bakingapp/activity/StepActivity.java
+++ b/app/src/main/java/com/udacity/bakingapp/activity/StepActivity.java
@@ -20,13 +20,17 @@ public class StepActivity extends AppCompatActivity {
         final Bundle arguments = getIntent().getExtras();
         Timber.d("Received bundle in StepActivity: " + arguments);
 
-
-        final RecipeStepFragment recipeStepFragment = new RecipeStepFragment();
-        recipeStepFragment.setArguments(arguments);
-        getSupportFragmentManager()
-                .beginTransaction()
-                .add(R.id.recipe_step_placeholder, recipeStepFragment)
-                .commit();
+        // create fragment if does not exist
+        RecipeStepFragment recipeStepFragment = (RecipeStepFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.recipe_step_placeholder);
+        if (recipeStepFragment == null) {
+            recipeStepFragment = new RecipeStepFragment();
+            recipeStepFragment.setArguments(arguments);
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .add(R.id.recipe_step_placeholder, recipeStepFragment)
+                    .commit();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/udacity/bakingapp/fragment/RecipeStepFragment.java
+++ b/app/src/main/java/com/udacity/bakingapp/fragment/RecipeStepFragment.java
@@ -45,6 +45,8 @@ public class RecipeStepFragment extends Fragment {
     private Guideline mGuideline;
     private TextView mDescription;
 
+    private String mediaURL;
+
     private Context mContext;
 
     private long mPlayerPosition;
@@ -81,7 +83,8 @@ public class RecipeStepFragment extends Fragment {
         Bundle arguments = getArguments();
 
         final String description = arguments.getString(EXTRA_DESCRIPTION);
-        final String mediaURL = arguments.getString(EXTRA_MEDIA_URL);
+        // Saved to variable for restoring exoplayer state in onResume
+        mediaURL = arguments.getString(EXTRA_MEDIA_URL);
 
         // Grab context of the running activity
         mContext = getActivity();
@@ -131,6 +134,8 @@ public class RecipeStepFragment extends Fragment {
 
     private void initializePlayer(String mediaURL) {
         if (mExoPlayer == null) {
+            Timber.d("Seting up exoplayer window " + mPlayerWindow +
+                    " at position " + mPlayerPosition + ", autoplay: " + mPlayerAutoplay);
             // Resource: https://gist.github.com/codeshifu/c26bb8a5f27f94d73b3a4888a509927c#file-mainactivity-java-L63
             mExoPlayer = ExoPlayerFactory.newSimpleInstance(
                     new DefaultRenderersFactory(mContext),
@@ -157,17 +162,13 @@ public class RecipeStepFragment extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
-        if (Util.SDK_INT <= 23) {
-            releasePlayer();
-        }
+        releasePlayer();
     }
 
     @Override
     public void onStop() {
         super.onStop();
-        if (Util.SDK_INT > 23) {
-            releasePlayer();
-        }
+        releasePlayer();
     }
 
     @Override
@@ -187,5 +188,11 @@ public class RecipeStepFragment extends Fragment {
             mExoPlayer.release();
             mExoPlayer = null;
         }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        initializePlayer(mediaURL);
     }
 }


### PR DESCRIPTION
When switching screens, the Android OS may kill the app to free resources. However, the fragments and exoplayer state can be restored when the app is brought back to focus.

Changes:
* If fragment still exists, use that instead of creating a new one (also prevents ghosting effect of RecipeStep RecyclerView)
* Restore exoplayer state when the fragment is resumed

Test Plan:
1. Open app and navigate to a StepActivity with exoplayer that should start playing automatically
2. Navigate away to any other application on device
3. Switch back to the Baking App
4. StepActivity should still be selected and exoplayer should start playing video where last left off